### PR TITLE
Add App.js and package.json with React Navigation integration

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,0 +1,155 @@
+/*
+ * Entry point for the SSocket MVP React Native app.
+ *
+ * This file sets up a simple stack navigator on top of a bottom tab
+ * navigator using React Navigation.  Screens are imported from the
+ * existing page files in the repository.  No files were renamed when
+ * wiring up navigation – instead we import them by their original
+ * names (spaces and apostrophes included).
+ *
+ * The navigation theme uses the project’s black/white/yellow colour
+ * palette.  Primary actions are highlighted in yellow, backgrounds are
+ * black and text is white.  The root stack includes routes for the
+ * bottom tab navigator plus detail views for user profiles, editing
+ * profiles and mini/mega contract screens.
+ */
+
+import React from "react";
+import { NavigationContainer, DefaultTheme } from "@react-navigation/native";
+import { createNativeStackNavigator } from "@react-navigation/native-stack";
+import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
+import { Ionicons } from "@expo/vector-icons";
+
+// Pull in existing screens from the repository.  These imports use
+// double‑quoted strings because some file names contain single quotes.
+import FeedScreen from "./Feed Page1";
+import ContactsScreen from "./Contact Page";
+import OtherUserProfileScreen from "./User's Profile Page";
+import TrackListScreen from "./Track List Page";
+import EditProfileScreen from "./Edit Profile Page";
+import HelpStatsScreen from "./Help Stat Page";
+import MiniContracteeScreen from "./User's Mini Contractee Page";
+import MiniContractorScreen from "./User's Mini Contractor Page";
+import MegaContractCreateScreen from "./Business Create Mega Contract Page";
+import MegaContractNegotiationScreen from "./Business mega contract negotiation page";
+
+// Define our colour palette
+const YELLOW = "#FFD54A";
+const BLACK = "#000";
+const WHITE = "#FFF";
+
+// Custom theme based on React Navigation’s default theme
+const MyTheme = {
+  ...DefaultTheme,
+  colors: {
+    ...DefaultTheme.colors,
+    primary: YELLOW,
+    background: BLACK,
+    card: BLACK,
+    text: WHITE,
+    border: YELLOW,
+    notification: YELLOW,
+  },
+};
+
+const Tab = createBottomTabNavigator();
+const Stack = createNativeStackNavigator();
+
+/**
+ * Bottom tab navigator configuration.
+ *
+ * Each tab is associated with one of the key application areas.  Icons
+ * from Ionicons are used to give users visual cues for each tab.  The
+ * tabBarActiveTintColor is set to our yellow to highlight the active
+ * route and the inactive tint is white to maintain contrast against
+ * the black background.
+ */
+function BottomTabs() {
+  return (
+    <Tab.Navigator
+      screenOptions={({ route }) => ({
+        headerShown: false,
+        tabBarStyle: { backgroundColor: BLACK },
+        tabBarActiveTintColor: YELLOW,
+        tabBarInactiveTintColor: WHITE,
+        tabBarIcon: ({ color, size }) => {
+          let iconName;
+          switch (route.name) {
+            case "Feed":
+              iconName = "home-outline";
+              break;
+            case "Contacts":
+              iconName = "people-outline";
+              break;
+            case "TrackList":
+              iconName = "list-outline";
+              break;
+            case "HelpStats":
+              iconName = "stats-chart-outline";
+              break;
+            default:
+              iconName = "ellipse-outline";
+          }
+          return <Ionicons name={iconName} size={size} color={color} />;
+        },
+      })}
+    >
+      <Tab.Screen name="Feed" component={FeedScreen} />
+      <Tab.Screen name="Contacts" component={ContactsScreen} />
+      <Tab.Screen name="TrackList" component={TrackListScreen} />
+      <Tab.Screen name="HelpStats" component={HelpStatsScreen} />
+    </Tab.Navigator>
+  );
+}
+
+/**
+ * Root stack navigator configuration.
+ *
+ * The first screen is the tab navigator itself.  Subsequent screens
+ * represent deeper routes that can be pushed onto the stack.  Keeping
+ * headerShown false for the tabs ensures we don’t render two headers
+ * simultaneously.
+ */
+export default function App() {
+  return (
+    <NavigationContainer theme={MyTheme}>
+      <Stack.Navigator>
+        <Stack.Screen
+          name="HomeTabs"
+          component={BottomTabs}
+          options={{ headerShown: false }}
+        />
+        <Stack.Screen
+          name="OtherUserProfile"
+          component={OtherUserProfileScreen}
+          options={{ title: "Profile" }}
+        />
+        <Stack.Screen
+          name="EditProfile"
+          component={EditProfileScreen}
+          options={{ title: "Edit Profile" }}
+        />
+        <Stack.Screen
+          name="MiniContractee"
+          component={MiniContracteeScreen}
+          options={{ title: "Mini Contract (Contractee)" }}
+        />
+        <Stack.Screen
+          name="MiniContractor"
+          component={MiniContractorScreen}
+          options={{ title: "Mini Contract (Contractor)" }}
+        />
+        <Stack.Screen
+          name="MegaContractCreate"
+          component={MegaContractCreateScreen}
+          options={{ title: "Create Mega Contract" }}
+        />
+        <Stack.Screen
+          name="MegaContractNegotiation"
+          component={MegaContractNegotiationScreen}
+          options={{ title: "Mega Contract Negotiation" }}
+        />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "SSocket-MVP",
+  "version": "1.0.0",
+  "private": true,
+  "main": "App.js",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios",
+    "web": "expo start --web"
+  },
+  "dependencies": {
+    "expo": "^49.0.0",
+    "react": "^18.2.0",
+    "react-native": "^0.72.0",
+    "react-native-screens": "^3.24.0",
+    "react-native-safe-area-context": "^4.8.0",
+    "@react-navigation/native": "^6.1.0",
+    "@react-navigation/native-stack": "^6.9.0",
+    "@react-navigation/bottom-tabs": "^6.5.0",
+    "@expo/vector-icons": "^13.0.0"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.20.0"
+  }
+}


### PR DESCRIPTION
## Summary

This PR introduces a new `App.js` that implements React Navigation throughout the MVP. It configures both a bottom tab navigator and a stack navigator using the existing screen components.

### Changes
- Added `App.js` to serve as the entry point. It sets up the navigation container with a custom black/white/yellow theme consistent with the existing UI.
- Implemented a bottom tab navigator with tabs for **Feed**, **Contacts**, **TrackList**, and **HelpStats**.
- Added a stack navigator for screens that are presented outside of the tab bar: **OtherUserProfile**, **EditProfile**, **MiniContract** (contractee and contractor views), and **MegaContract** (create and negotiation views).
- Added `package.json` with Expo and React Navigation dependencies (e.g., `@react-navigation/native`, `@react-navigation/native-stack`, `@react-navigation/bottom-tabs`, `react-native-screens`, `react-native-safe-area-context`).

### Testing
1. Pull this branch and install dependencies (`npm install` or `yarn`).
2. Run the project with Expo (`expo start`).
3. On launch you should land on the **Feed** screen with a bottom tab bar.
4. Use the tab bar to switch between **Feed**, **Contacts**, **TrackList**, and **HelpStats**.
5. From any tab, navigate to other screens via links or buttons within each screen (e.g. open a user’s profile to see the **OtherUserProfile** screen). Each screen should adopt the black/white/yellow theme.

Let me know if there are any issues or further refinements needed.
