### PR TITLE
Diagnostic: Expo URL (manual entry)

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,0 +1,6 @@
+import React from "react";
+import TestPage from "./TestPage";
+
+export default function App() {
+  return <TestPage />;
+}

--- a/TestPage.js
+++ b/TestPage.js
@@ -1,0 +1,16 @@
+import React from "react";
+import { SafeAreaView, Text, StyleSheet } from "react-native";
+
+export default function TestPage() {
+  return (
+    <SafeAreaView style={styles.center}>
+      <Text style={styles.title}>\u2705 Expo Go Test Page</Text>
+      <Text>Enter the URL manually in Expo Go.</Text>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  center: { flex: 1, justifyContent: "center", alignItems: "center" },
+  title: { fontSize: 20, fontWeight: "bold", marginBottom: 10 }
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "ssocket-mvp",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "start": "expo start",
+    "start:tunnel": "expo start --tunnel"
+  },
+  "dependencies": {
+    "expo": "latest",
+    "react": "latest",
+    "react-native": "latest"
+  }
+}


### PR DESCRIPTION
This PR adds TestPage.js and sets App.js to render it for manual Expo URL diagnostic. It adds minimal package.json with Expo scripts. Once merged, you can run `npm run start:tunnel` to obtain the Expo URL for manual entry in Expo Go.